### PR TITLE
Fixing an error in the call chain for discount calculator

### DIFF
--- a/LevelUpIntegrationSdk/LevelUp.Api.Utilities.Test/PaymentCalculatorTests.cs
+++ b/LevelUpIntegrationSdk/LevelUp.Api.Utilities.Test/PaymentCalculatorTests.cs
@@ -24,6 +24,8 @@ namespace LevelUp.Api.Utilities.Test
     [TestClass]
     public class PaymentCalculatorTests
     {
+        private const decimal DOLLARS_TO_CENTS_CONVERT_FACTOR = 100;
+
         [TestClass]
         public class DiscountToApplyTests
         {
@@ -32,8 +34,18 @@ namespace LevelUp.Api.Utilities.Test
             {
                 const decimal merchantCredit = 10m;
                 const decimal amountDueBeforeTax = 5m;
+                const decimal expectedDiscount = 5m;
 
-                PaymentCalculator.CalculateDiscountToApply(merchantCredit, amountDueBeforeTax).Should().Be(5);
+                PaymentCalculator.CalculateDiscountToApply(merchantCredit, amountDueBeforeTax)
+                                 .Should()
+                                 .Be(expectedDiscount);
+
+                long merchantCreditInCents = Convert.ToInt64(merchantCredit * DOLLARS_TO_CENTS_CONVERT_FACTOR);
+                long amountDueBeforeTaxInCents = Convert.ToInt64(amountDueBeforeTax * DOLLARS_TO_CENTS_CONVERT_FACTOR);
+
+                PaymentCalculator.CalculateDiscountToApply(merchantCreditInCents, amountDueBeforeTaxInCents)
+                                 .Should()
+                                 .Be(expectedDiscount);
             }
 
             [TestMethod]
@@ -57,8 +69,18 @@ namespace LevelUp.Api.Utilities.Test
             {
                 const decimal merchantCredit = 2m;
                 const decimal amountDueBeforeTax = 10m;
+                const decimal expectedDiscount = 2m;
 
-                PaymentCalculator.CalculateDiscountToApply(merchantCredit, amountDueBeforeTax).Should().Be(2);
+                PaymentCalculator.CalculateDiscountToApply(merchantCredit, amountDueBeforeTax)
+                                 .Should()
+                                 .Be(expectedDiscount);
+
+                long merchantCreditInCents = Convert.ToInt64(merchantCredit * DOLLARS_TO_CENTS_CONVERT_FACTOR);
+                long amountDueBeforeTaxInCents = Convert.ToInt64(amountDueBeforeTax * DOLLARS_TO_CENTS_CONVERT_FACTOR);
+
+                PaymentCalculator.CalculateDiscountToApply(merchantCreditInCents, amountDueBeforeTaxInCents)
+                                 .Should()
+                                 .Be(expectedDiscount);
             }
 
             [TestMethod]

--- a/LevelUpIntegrationSdk/LevelUp.Api.Utilities/PaymentCalculator.cs
+++ b/LevelUpIntegrationSdk/LevelUp.Api.Utilities/PaymentCalculator.cs
@@ -59,7 +59,8 @@ namespace LevelUp.Api.Utilities
             return CalculateDiscountToApply(merchantFundedCreditAvailableInCents,
                                             amountDueInCents,
                                             amountDueInCents,
-                                            taxAmountDueInCents);
+                                            taxAmountDueInCents,
+                                            0);
         }
 
         /// <summary>


### PR DESCRIPTION
When arguments with type `long` were passed to the `PaymentCalculator.CalculateDiscountToApply()` method, we had omitted an important arg resulting in the wrong method being called with the wrong arg values ultimately leading to the wrong value for the discount to apply being returned.

This changeset fixes the call chain issue and adds tests to guard against this happening in the future.
